### PR TITLE
【ホーム】最近の対局にグループやシーズン情報追加表示、デザイン変更

### DIFF
--- a/jong_connect/lib/data/group_matches_repository.dart
+++ b/jong_connect/lib/data/group_matches_repository.dart
@@ -21,6 +21,12 @@ class GroupMatchesRepository {
     throw UnimplementedError();
   }
 
+  @override
+  Future<List<GroupMatch>> getRecentlyMatchesInGroups(List<int> groupIds,
+      {int limit = 10}) async {
+    throw UnimplementedError();
+  }
+
   Stream<GroupMatch?> getLatestGroupMatchStream(int groupId) {
     throw UnimplementedError();
   }

--- a/jong_connect/lib/data/group_matches_repository_impl.dart
+++ b/jong_connect/lib/data/group_matches_repository_impl.dart
@@ -12,12 +12,18 @@ class GroupMatchesRepositoryImpl implements GroupMatchesRepository {
       season_id,
       created_at, 
       end_at,
+      groups (
+         *
+      ),
+      seasons (
+         *
+      ),
       users (
-          id,
-          name, 
-          profile, 
-          avatar_url,
-          friend_id
+        id,
+        name, 
+        profile, 
+        avatar_url,
+        friend_id
       ),
       match_type, 
       group_match_results (
@@ -59,6 +65,19 @@ class GroupMatchesRepositoryImpl implements GroupMatchesRepository {
         .from('group_matches')
         .select(_columns)
         .eq('group_id', groupId)
+        .order('created_at', ascending: false)
+        .limit(limit);
+
+    return json.map<GroupMatch>((match) => GroupMatch.fromJson(match)).toList();
+  }
+
+  @override
+  Future<List<GroupMatch>> getRecentlyMatchesInGroups(List<int> groupIds,
+      {int limit = 10}) async {
+    final json = await supabase
+        .from('group_matches')
+        .select(_columns)
+        .filter('group_id', 'in', groupIds)
         .order('created_at', ascending: false)
         .limit(limit);
 

--- a/jong_connect/lib/data/group_matches_repository_impl.dart
+++ b/jong_connect/lib/data/group_matches_repository_impl.dart
@@ -142,7 +142,7 @@ class GroupMatchesRepositoryImpl implements GroupMatchesRepository {
   @override
   Future<void> closeMatch(int groupMatchId) async {
     await supabase.from('group_matches').update(
-        {'end_at': DateTime.now().toIso8601String()}).eq('id', groupMatchId);
+        {'end_at': DateTime.now().toUtc().toString()}).eq('id', groupMatchId);
   }
 
   @override

--- a/jong_connect/lib/data/groups_repository.dart
+++ b/jong_connect/lib/data/groups_repository.dart
@@ -15,6 +15,10 @@ class GroupsRepository {
     throw UnimplementedError();
   }
 
+  Future<List<Group>> getGroups() async {
+    throw UnimplementedError();
+  }
+
   Stream<List<Group>> getGroupsStream() async* {
     throw UnimplementedError();
   }

--- a/jong_connect/lib/data/groups_repository_impl.dart
+++ b/jong_connect/lib/data/groups_repository_impl.dart
@@ -30,6 +30,26 @@ class GroupsRepositoryImpl implements GroupsRepository {
   }
 
   @override
+  Future<List<Group>> getGroups() async {
+    final groups = await supabase.from('groups').select('''
+      id, 
+      name, 
+      description, 
+      image_url,
+      user_joinned_groups (
+        users (
+          id,
+          name, 
+          profile, 
+          avatar_url,
+          friend_id
+        )
+      )
+    ''');
+    return groups.map<Group>((json) => Group.fromJson(json)).toList();
+  }
+
+  @override
   Stream<List<Group>> getGroupsStream() {
     // TODO: グループの更新が新しい順に並べる
     return supabase.from('groups').stream(primaryKey: ['id'])

--- a/jong_connect/lib/domain/model/group_match.dart
+++ b/jong_connect/lib/domain/model/group_match.dart
@@ -27,7 +27,7 @@ class GroupMatch with _$GroupMatch {
     @JsonKey(name: 'users') AppUser? createdBy,
     @JsonKey(name: 'end_at') DateTime? endAt,
     @JsonKey(name: 'season_id') int? seasonId,
-    @JsonKey(name: 'season') Season? season,
+    @JsonKey(name: 'seasons') Season? season,
     @JsonKey(name: 'group_match_results') List<GroupMatchResult>? results,
   }) = _GroupMatch;
 

--- a/jong_connect/lib/domain/model/group_match.freezed.dart
+++ b/jong_connect/lib/domain/model/group_match.freezed.dart
@@ -35,7 +35,7 @@ mixin _$GroupMatch {
   DateTime? get endAt => throw _privateConstructorUsedError;
   @JsonKey(name: 'season_id')
   int? get seasonId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'season')
+  @JsonKey(name: 'seasons')
   Season? get season => throw _privateConstructorUsedError;
   @JsonKey(name: 'group_match_results')
   List<GroupMatchResult>? get results => throw _privateConstructorUsedError;
@@ -65,7 +65,7 @@ abstract class $GroupMatchCopyWith<$Res> {
       @JsonKey(name: 'users') AppUser? createdBy,
       @JsonKey(name: 'end_at') DateTime? endAt,
       @JsonKey(name: 'season_id') int? seasonId,
-      @JsonKey(name: 'season') Season? season,
+      @JsonKey(name: 'seasons') Season? season,
       @JsonKey(name: 'group_match_results') List<GroupMatchResult>? results});
 
   $GroupCopyWith<$Res>? get group;
@@ -203,7 +203,7 @@ abstract class _$$GroupMatchImplCopyWith<$Res>
       @JsonKey(name: 'users') AppUser? createdBy,
       @JsonKey(name: 'end_at') DateTime? endAt,
       @JsonKey(name: 'season_id') int? seasonId,
-      @JsonKey(name: 'season') Season? season,
+      @JsonKey(name: 'seasons') Season? season,
       @JsonKey(name: 'group_match_results') List<GroupMatchResult>? results});
 
   @override
@@ -296,7 +296,7 @@ class _$GroupMatchImpl extends _GroupMatch {
       @JsonKey(name: 'users') this.createdBy,
       @JsonKey(name: 'end_at') this.endAt,
       @JsonKey(name: 'season_id') this.seasonId,
-      @JsonKey(name: 'season') this.season,
+      @JsonKey(name: 'seasons') this.season,
       @JsonKey(name: 'group_match_results')
       final List<GroupMatchResult>? results})
       : _results = results,
@@ -329,7 +329,7 @@ class _$GroupMatchImpl extends _GroupMatch {
   @JsonKey(name: 'season_id')
   final int? seasonId;
   @override
-  @JsonKey(name: 'season')
+  @JsonKey(name: 'seasons')
   final Season? season;
   final List<GroupMatchResult>? _results;
   @override
@@ -409,7 +409,7 @@ abstract class _GroupMatch extends GroupMatch {
       @JsonKey(name: 'users') final AppUser? createdBy,
       @JsonKey(name: 'end_at') final DateTime? endAt,
       @JsonKey(name: 'season_id') final int? seasonId,
-      @JsonKey(name: 'season') final Season? season,
+      @JsonKey(name: 'seasons') final Season? season,
       @JsonKey(name: 'group_match_results')
       final List<GroupMatchResult>? results}) = _$GroupMatchImpl;
   const _GroupMatch._() : super._();
@@ -441,7 +441,7 @@ abstract class _GroupMatch extends GroupMatch {
   @JsonKey(name: 'season_id')
   int? get seasonId;
   @override
-  @JsonKey(name: 'season')
+  @JsonKey(name: 'seasons')
   Season? get season;
   @override
   @JsonKey(name: 'group_match_results')

--- a/jong_connect/lib/domain/model/group_match.g.dart
+++ b/jong_connect/lib/domain/model/group_match.g.dart
@@ -22,9 +22,9 @@ _$GroupMatchImpl _$$GroupMatchImplFromJson(Map<String, dynamic> json) =>
           ? null
           : DateTime.parse(json['end_at'] as String),
       seasonId: (json['season_id'] as num?)?.toInt(),
-      season: json['season'] == null
+      season: json['seasons'] == null
           ? null
-          : Season.fromJson(json['season'] as Map<String, dynamic>),
+          : Season.fromJson(json['seasons'] as Map<String, dynamic>),
       results: (json['group_match_results'] as List<dynamic>?)
           ?.map((e) => GroupMatchResult.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -40,7 +40,7 @@ Map<String, dynamic> _$$GroupMatchImplToJson(_$GroupMatchImpl instance) =>
       'users': instance.createdBy?.toJson(),
       'end_at': instance.endAt?.toIso8601String(),
       'season_id': instance.seasonId,
-      'season': instance.season?.toJson(),
+      'seasons': instance.season?.toJson(),
       'group_match_results': instance.results?.map((e) => e.toJson()).toList(),
     };
 

--- a/jong_connect/lib/domain/provider/recently_match_results.dart
+++ b/jong_connect/lib/domain/provider/recently_match_results.dart
@@ -1,15 +1,16 @@
 import 'dart:async';
 
-import 'package:jong_connect/data/group_match_results_repository.dart';
-import 'package:jong_connect/domain/model/group_round_match_result.dart';
 import 'package:jong_connect/domain/provider/current_user.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../data/group_matches_repository.dart';
+import '../../data/groups_repository.dart';
+import '../model/group_match.dart';
 
 part 'recently_match_results.g.dart';
 
 @riverpod
-Future<List<GroupRoundMatchResult>> recentlyMatchResults(
-    RecentlyMatchResultsRef ref,
+Future<List<GroupMatch>> recentlyMatchResults(RecentlyMatchResultsRef ref,
     {int limit = 3}) async {
   final user = await ref.watch(currentUserProvider.future);
 
@@ -17,7 +18,15 @@ Future<List<GroupRoundMatchResult>> recentlyMatchResults(
     return [];
   }
 
+  final joinedGroups = await ref.watch(groupsRepositoryProvider).getGroups();
+
+  if (joinedGroups.isEmpty) {
+    return [];
+  }
+
+  final joinedGroupIds = joinedGroups.map((group) => group.id).toList();
+
   return await ref
-      .read(groupMatchResultsRepositoryProvider)
-      .getRecentlyResults(user.id, limit: limit);
+      .read(groupMatchesRepositoryProvider)
+      .getRecentlyMatchesInGroups(joinedGroupIds, limit: limit);
 }

--- a/jong_connect/lib/domain/provider/recently_match_results.g.dart
+++ b/jong_connect/lib/domain/provider/recently_match_results.g.dart
@@ -7,7 +7,7 @@ part of 'recently_match_results.dart';
 // **************************************************************************
 
 String _$recentlyMatchResultsHash() =>
-    r'e43e35e22aa7ddd904de0e28634606dc2c550863';
+    r'3ee296cfad224b30ff3b14044a35e56844c4048e';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -35,8 +35,7 @@ class _SystemHash {
 const recentlyMatchResultsProvider = RecentlyMatchResultsFamily();
 
 /// See also [recentlyMatchResults].
-class RecentlyMatchResultsFamily
-    extends Family<AsyncValue<List<GroupRoundMatchResult>>> {
+class RecentlyMatchResultsFamily extends Family<AsyncValue<List<GroupMatch>>> {
   /// See also [recentlyMatchResults].
   const RecentlyMatchResultsFamily();
 
@@ -75,7 +74,7 @@ class RecentlyMatchResultsFamily
 
 /// See also [recentlyMatchResults].
 class RecentlyMatchResultsProvider
-    extends AutoDisposeFutureProvider<List<GroupRoundMatchResult>> {
+    extends AutoDisposeFutureProvider<List<GroupMatch>> {
   /// See also [recentlyMatchResults].
   RecentlyMatchResultsProvider({
     int limit = 3,
@@ -110,8 +109,7 @@ class RecentlyMatchResultsProvider
 
   @override
   Override overrideWith(
-    FutureOr<List<GroupRoundMatchResult>> Function(
-            RecentlyMatchResultsRef provider)
+    FutureOr<List<GroupMatch>> Function(RecentlyMatchResultsRef provider)
         create,
   ) {
     return ProviderOverride(
@@ -129,8 +127,7 @@ class RecentlyMatchResultsProvider
   }
 
   @override
-  AutoDisposeFutureProviderElement<List<GroupRoundMatchResult>>
-      createElement() {
+  AutoDisposeFutureProviderElement<List<GroupMatch>> createElement() {
     return _RecentlyMatchResultsProviderElement(this);
   }
 
@@ -149,13 +146,13 @@ class RecentlyMatchResultsProvider
 }
 
 mixin RecentlyMatchResultsRef
-    on AutoDisposeFutureProviderRef<List<GroupRoundMatchResult>> {
+    on AutoDisposeFutureProviderRef<List<GroupMatch>> {
   /// The parameter `limit` of this provider.
   int get limit;
 }
 
 class _RecentlyMatchResultsProviderElement
-    extends AutoDisposeFutureProviderElement<List<GroupRoundMatchResult>>
+    extends AutoDisposeFutureProviderElement<List<GroupMatch>>
     with RecentlyMatchResultsRef {
   _RecentlyMatchResultsProviderElement(super.provider);
 

--- a/jong_connect/lib/presentation/common_widgets/group_match_result_summary.dart
+++ b/jong_connect/lib/presentation/common_widgets/group_match_result_summary.dart
@@ -1,0 +1,150 @@
+import 'dart:collection';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:jong_connect/domain/model/app_user.dart';
+import 'package:jong_connect/domain/model/group_match.dart';
+import 'package:jong_connect/util/app_sizes.dart';
+import '../../../util/routing_path.dart';
+import '../../util/format_date.dart';
+
+class GroupMatchResultSummary extends StatelessWidget {
+  const GroupMatchResultSummary({super.key, required this.match});
+
+  final GroupMatch match;
+
+  @override
+  Widget build(BuildContext context) {
+    if (match.results!.isEmpty) {
+      return const SizedBox();
+    }
+
+    final size = MediaQuery.of(context).size;
+    final startAt = DateFormatter(match.createdAt).formatToYYYYMMDDHHmm();
+    final endAt = match.endAt != null
+        ? DateFormatter(match.endAt!).formatToYYYYMMDDHHmm()
+        : "";
+
+    return GestureDetector(
+      onTap: () => {
+        context.goNamed(
+          RoutingPath.groupMatch,
+          pathParameters: {
+            'groupId': match.groupId.toString(),
+            'groupMatchId': match.id.toString(),
+          },
+        )
+      },
+      child: Container(
+        height: size.height * 0.25,
+        padding: paddingV8H8,
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surfaceContainerHigh,
+          borderRadius: const BorderRadius.all(
+            Radius.circular(10),
+          ),
+        ),
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(match.group!.name),
+                Text(match.season?.name ?? ""),
+              ],
+            ),
+            gapH4,
+            Row(
+              children: [
+                Text(startAt),
+                if (match.isFinish) ...[
+                  gapW8,
+                  const Text("-"),
+                  gapW8,
+                  Text(endAt),
+                ]
+              ],
+            ),
+            gapH8,
+            Expanded(
+              child: _GroupMatchResultListView(match: match),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GroupMatchResultListView extends StatelessWidget {
+  const _GroupMatchResultListView({super.key, required this.match});
+
+  final GroupMatch match;
+  final int rowCount = 2;
+
+  @override
+  Widget build(BuildContext context) {
+    var totalResults = match.totalPointsPerUser;
+    var sortedResults = SplayTreeMap<String, int>.from(
+        totalResults, (a, b) => totalResults[b]!.compareTo(totalResults[a]!));
+    var playerIds = sortedResults.keys.toList();
+    var playerMap = Map.fromIterables(
+        match.joinUsers.map<String>((user) => user.id).toList(),
+        match.joinUsers.map<AppUser>((user) => user).toList());
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          for (var playerId in playerIds)
+            _UserScoreListItem(
+              user: playerMap[playerId]!,
+              score: sortedResults[playerId]!,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _UserScoreListItem extends StatelessWidget {
+  const _UserScoreListItem(
+      {super.key, required this.user, required this.score});
+
+  final AppUser user;
+  final int score;
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    return SizedBox(
+      width: size.width * 0.2,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Expanded(
+            child: CachedNetworkImage(
+              imageUrl: user.avatarUrl,
+              imageBuilder: (context, imageProvider) => CircleAvatar(
+                radius: 40,
+                child: Container(
+                  decoration: BoxDecoration(
+                    image: DecorationImage(
+                      image: imageProvider,
+                      fit: BoxFit.contain,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          gapH4,
+          Text(user.name),
+          gapH8,
+          Text(score.toString()),
+        ],
+      ),
+    );
+  }
+}

--- a/jong_connect/lib/presentation/common_widgets/group_match_result_summary.dart
+++ b/jong_connect/lib/presentation/common_widgets/group_match_result_summary.dart
@@ -8,6 +8,7 @@ import 'package:jong_connect/domain/model/group_match.dart';
 import 'package:jong_connect/util/app_sizes.dart';
 import '../../../util/routing_path.dart';
 import '../../util/format_date.dart';
+import '../../util/score_color.dart';
 
 class GroupMatchResultSummary extends StatelessWidget {
   const GroupMatchResultSummary({super.key, required this.match});
@@ -50,7 +51,13 @@ class GroupMatchResultSummary extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(match.group!.name),
+                Text(
+                  match.group!.name,
+                  style: const TextStyle(
+                    fontSize: Sizes.p20,
+                    fontWeight: FontWeight.w200,
+                  ),
+                ),
                 Text(match.season?.name ?? ""),
               ],
             ),
@@ -141,8 +148,14 @@ class _UserScoreListItem extends StatelessWidget {
           ),
           gapH4,
           Text(user.name),
-          gapH8,
-          Text(score.toString()),
+          gapH4,
+          Text(
+            score.toString(),
+            style: TextStyle(
+              fontSize: 16,
+              color: scoreColor(context, score),
+            ),
+          ),
         ],
       ),
     );

--- a/jong_connect/lib/presentation/pages/group_details/group_match_histories_section.dart
+++ b/jong_connect/lib/presentation/pages/group_details/group_match_histories_section.dart
@@ -1,12 +1,8 @@
-import 'dart:collection';
-
 import 'package:async_value_group/async_value_group.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:chat_bubbles/bubbles/bubble_normal.dart';
-import 'package:data_table_2/data_table_2.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:grouped_list/grouped_list.dart';
 import 'package:jong_connect/domain/model/group_match.dart';
 import 'package:jong_connect/domain/provider/current_user.dart';
@@ -17,7 +13,7 @@ import 'package:jong_connect/util/constants.dart';
 
 import '../../../domain/model/app_user.dart';
 import '../../../util/format_date.dart';
-import '../../../util/routing_path.dart';
+import '../../common_widgets/group_match_result_summary.dart';
 
 class GroupMatchHistoriesSection extends ConsumerWidget {
   const GroupMatchHistoriesSection({super.key, required this.id});
@@ -154,93 +150,12 @@ class _MatchHistoryItem extends StatelessWidget {
           ),
           tail: false,
         ),
-        _ResultView(match: match),
-      ],
-    );
-  }
-}
-
-class _ResultView extends StatelessWidget {
-  const _ResultView({required this.match});
-
-  final GroupMatch match;
-  final int rowCount = 2;
-
-  @override
-  Widget build(BuildContext context) {
-    var totalResults = match.totalPointsPerUser;
-    var sortedResults = SplayTreeMap<String, int>.from(
-        totalResults, (a, b) => totalResults[b]!.compareTo(totalResults[a]!));
-    var playerIds = sortedResults.keys.toList();
-    var playerMap = Map.fromIterables(
-        match.joinUsers.map<String>((user) => user.id).toList(),
-        match.joinUsers.map<String>((user) => user.name).toList());
-
-    return GestureDetector(
-      onTap: () => {
-        context.goNamed(
-          RoutingPath.groupMatch,
-          pathParameters: {
-            'groupId': match.groupId.toString(),
-            'groupMatchId': match.id.toString(),
-          },
-        )
-      },
-      child: Container(
-        height: 180,
-        padding: paddingV8H8,
-        color: Theme.of(context).colorScheme.surfaceContainerHigh,
-        child: DataTable2(
-          columnSpacing: 12,
-          horizontalMargin: 12,
-          dataRowHeight: 30,
-          headingRowHeight: 30,
-          sortColumnIndex: 1,
-          columns: [
-            DataColumn2(
-              label: Text(
-                '参加ユーザー',
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.inverseSurface,
-                ),
-              ),
-              size: ColumnSize.L,
-            ),
-            DataColumn(
-              label: Text(
-                '${match.isFinish ? '最終' : '途中'}スコア',
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.inverseSurface,
-                ),
-              ),
-              numeric: true,
-            ),
-          ],
-          rows: List<DataRow>.generate(
-            sortedResults.length,
-            (index) => DataRow(
-              cells: [
-                DataCell(
-                  Text(
-                    playerMap[playerIds[index]]!,
-                    style: TextStyle(
-                      color: Theme.of(context).colorScheme.inverseSurface,
-                    ),
-                  ),
-                ),
-                DataCell(
-                  Text(
-                    sortedResults[playerIds[index]].toString(),
-                    style: TextStyle(
-                      color: Theme.of(context).colorScheme.inverseSurface,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
+        gapH4,
+        GroupMatchResultSummary(
+          match: match,
         ),
-      ),
+        gapH4,
+      ],
     );
   }
 }

--- a/jong_connect/lib/presentation/pages/home/home_page.dart
+++ b/jong_connect/lib/presentation/pages/home/home_page.dart
@@ -1,29 +1,54 @@
+import 'dart:math';
+
+import 'package:custom_refresh_indicator/custom_refresh_indicator.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:jong_connect/presentation/pages/home/my_profile_section.dart';
 import 'package:jong_connect/presentation/pages/home/recently_match_results_section.dart';
 import 'package:jong_connect/util/app_sizes.dart';
 
-class HomePage extends StatelessWidget {
+import '../../../domain/provider/recently_match_results.dart';
+
+class HomePage extends ConsumerWidget {
   const HomePage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.primary,
         foregroundColor: Theme.of(context).colorScheme.surface,
         title: const Text('ホーム'),
       ),
-      body: const SingleChildScrollView(
-        padding: paddingV20H16,
-        child: Column(
-          children: [
-            MyProfileSection(),
-            gapH8,
-            RecentlyGroupMatchesSection(),
-          ],
+      body: CustomMaterialIndicator(
+        onRefresh: () => onRefresh(ref),
+        backgroundColor: Colors.white,
+        indicatorBuilder: (context, controller) {
+          return Padding(
+            padding: const EdgeInsets.all(6.0),
+            child: CircularProgressIndicator(
+              color: Colors.redAccent,
+              value: controller.state.isLoading
+                  ? null
+                  : min(controller.value, 1.0),
+            ),
+          );
+        },
+        child: const SingleChildScrollView(
+          padding: paddingV20H16,
+          child: Column(
+            children: [
+              MyProfileSection(),
+              gapH8,
+              RecentlyGroupMatchesSection(),
+            ],
+          ),
         ),
       ),
     );
+  }
+
+  Future<void> onRefresh(WidgetRef ref) async {
+    ref.invalidate(recentlyMatchResultsProvider);
   }
 }

--- a/jong_connect/lib/presentation/pages/home/home_page.dart
+++ b/jong_connect/lib/presentation/pages/home/home_page.dart
@@ -20,7 +20,7 @@ class HomePage extends StatelessWidget {
           children: [
             MyProfileSection(),
             gapH8,
-            RecentlyMatchResultsSection(),
+            RecentlyGroupMatchesSection(),
           ],
         ),
       ),

--- a/jong_connect/lib/presentation/pages/home/recently_match_results_section.dart
+++ b/jong_connect/lib/presentation/pages/home/recently_match_results_section.dart
@@ -3,17 +3,19 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
-import 'package:jong_connect/domain/model/group_round_match_result.dart';
+import 'package:jong_connect/domain/model/group_match.dart';
+import 'package:jong_connect/domain/provider/group_match.dart';
 import 'package:jong_connect/domain/provider/recently_match_results.dart';
 import 'package:jong_connect/presentation/common_widgets/async_value_widget.dart';
 import 'package:jong_connect/util/app_icon_urls.dart';
 import 'package:jong_connect/util/app_sizes.dart';
 import 'package:jong_connect/util/format_date.dart';
 
+import '../../../domain/model/group_round_match_result.dart';
 import '../../common_widgets/user_profile_dialog.dart';
 
-class RecentlyMatchResultsSection extends ConsumerWidget {
-  const RecentlyMatchResultsSection({super.key});
+class RecentlyGroupMatchesSection extends ConsumerWidget {
+  const RecentlyGroupMatchesSection({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -46,29 +48,89 @@ class _TitleSection extends StatelessWidget {
 class _ResultsList extends ConsumerWidget {
   const _ResultsList({super.key});
 
-  final int maxDispCount = 10; // 最大表示件数
+  final int maxDispCount = 3; // 最大表示件数
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return AsyncValueWidget(
       asyncValue: ref.watch(recentlyMatchResultsProvider(limit: maxDispCount)),
-      data: (roundResults) {
+      data: (groupMatches) {
         return Column(
           children: [
-            if (roundResults.isEmpty) ...[
+            if (groupMatches.isEmpty) ...[
               const Center(
                 child: Text('直近の対局結果はありません'),
               ),
             ] else ...[
-              for (var roundResult in roundResults) ...{
-                _ResultListTile(
-                  roundResult: roundResult,
+              for (var groupMatch in groupMatches) ...{
+                _GroupMatchListTile(
+                  groupMatch: groupMatch,
                 ),
+                gapH8,
               },
             ],
           ],
         );
       },
+    );
+  }
+}
+
+class _GroupMatchListTile extends StatelessWidget {
+  const _GroupMatchListTile({super.key, required this.groupMatch});
+
+  final GroupMatch groupMatch;
+
+  @override
+  Widget build(BuildContext context) {
+    if (groupMatch.results!.isEmpty) {
+      return const SizedBox();
+    }
+
+    final startAt = DateFormatter(groupMatch.createdAt).formatToYYYYMMDDHHmm();
+    final endAt = groupMatch.endAt != null
+        ? DateFormatter(groupMatch.endAt!).formatToYYYYMMDDHHmm()
+        : "";
+
+    return Container(
+      padding: paddingV8H8,
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHigh,
+        borderRadius: const BorderRadius.all(
+          Radius.circular(10),
+        ),
+      ),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(groupMatch.group!.name),
+              Text(groupMatch.season?.name ?? ""),
+            ],
+          ),
+          gapH4,
+          Row(
+            children: [
+              Text(startAt),
+              if (endAt.isNotEmpty) ...[
+                gapW8,
+                const Text("-"),
+                gapW8,
+                Text(endAt),
+              ]
+            ],
+          ),
+          gapH8,
+          for (var matchResult in groupMatch.results!) ...[
+            Text(matchResult.matchOrder.toString()),
+            Text(matchResult.userDisplayName.toString()),
+            Text(matchResult.score.toString()),
+            Text(matchResult.rank.toString()),
+            // _ResultListTile(roundResult: roundResult)
+          ]
+        ],
+      ),
     );
   }
 }
@@ -81,11 +143,14 @@ class _ResultListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dateFormatter = DateFormatter(roundResult.results.first.createdAt);
+
     return Padding(
       padding: paddingV8H8,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // TODO: グループ名とシーズンセクション追加
+          // TODO: 対戦日付のセクション修正
           Text(
             dateFormatter.formatToYYYYMMDDHHmm(),
             style: TextStyle(

--- a/jong_connect/lib/presentation/pages/home/recently_match_results_section.dart
+++ b/jong_connect/lib/presentation/pages/home/recently_match_results_section.dart
@@ -40,7 +40,7 @@ class _TitleSection extends StatelessWidget {
 class _ResultsList extends ConsumerWidget {
   const _ResultsList({super.key});
 
-  final int maxDispCount = 3; // 最大表示件数
+  final int maxDispCount = 5; // 最大表示件数
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/jong_connect/lib/presentation/pages/home/recently_match_results_section.dart
+++ b/jong_connect/lib/presentation/pages/home/recently_match_results_section.dart
@@ -1,18 +1,10 @@
-import 'package:auto_size_text/auto_size_text.dart';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
-import 'package:jong_connect/domain/model/group_match.dart';
-import 'package:jong_connect/domain/provider/group_match.dart';
 import 'package:jong_connect/domain/provider/recently_match_results.dart';
 import 'package:jong_connect/presentation/common_widgets/async_value_widget.dart';
-import 'package:jong_connect/util/app_icon_urls.dart';
 import 'package:jong_connect/util/app_sizes.dart';
-import 'package:jong_connect/util/format_date.dart';
 
-import '../../../domain/model/group_round_match_result.dart';
-import '../../common_widgets/user_profile_dialog.dart';
+import '../../common_widgets/group_match_result_summary.dart';
 
 class RecentlyGroupMatchesSection extends ConsumerWidget {
   const RecentlyGroupMatchesSection({super.key});
@@ -63,8 +55,8 @@ class _ResultsList extends ConsumerWidget {
               ),
             ] else ...[
               for (var groupMatch in groupMatches) ...{
-                _GroupMatchListTile(
-                  groupMatch: groupMatch,
+                GroupMatchResultSummary(
+                  match: groupMatch,
                 ),
                 gapH8,
               },
@@ -72,198 +64,6 @@ class _ResultsList extends ConsumerWidget {
           ],
         );
       },
-    );
-  }
-}
-
-class _GroupMatchListTile extends StatelessWidget {
-  const _GroupMatchListTile({super.key, required this.groupMatch});
-
-  final GroupMatch groupMatch;
-
-  @override
-  Widget build(BuildContext context) {
-    if (groupMatch.results!.isEmpty) {
-      return const SizedBox();
-    }
-
-    final startAt = DateFormatter(groupMatch.createdAt).formatToYYYYMMDDHHmm();
-    final endAt = groupMatch.endAt != null
-        ? DateFormatter(groupMatch.endAt!).formatToYYYYMMDDHHmm()
-        : "";
-
-    return Container(
-      padding: paddingV8H8,
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceContainerHigh,
-        borderRadius: const BorderRadius.all(
-          Radius.circular(10),
-        ),
-      ),
-      child: Column(
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(groupMatch.group!.name),
-              Text(groupMatch.season?.name ?? ""),
-            ],
-          ),
-          gapH4,
-          Row(
-            children: [
-              Text(startAt),
-              if (endAt.isNotEmpty) ...[
-                gapW8,
-                const Text("-"),
-                gapW8,
-                Text(endAt),
-              ]
-            ],
-          ),
-          gapH8,
-          for (var matchResult in groupMatch.results!) ...[
-            Text(matchResult.matchOrder.toString()),
-            Text(matchResult.userDisplayName.toString()),
-            Text(matchResult.score.toString()),
-            Text(matchResult.rank.toString()),
-            // _ResultListTile(roundResult: roundResult)
-          ]
-        ],
-      ),
-    );
-  }
-}
-
-class _ResultListTile extends StatelessWidget {
-  const _ResultListTile({super.key, required this.roundResult});
-
-  final GroupRoundMatchResult roundResult;
-
-  @override
-  Widget build(BuildContext context) {
-    final dateFormatter = DateFormatter(roundResult.results.first.createdAt);
-
-    return Padding(
-      padding: paddingV8H8,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // TODO: グループ名とシーズンセクション追加
-          // TODO: 対戦日付のセクション修正
-          Text(
-            dateFormatter.formatToYYYYMMDDHHmm(),
-            style: TextStyle(
-              color: Theme.of(context).colorScheme.outline,
-            ),
-          ),
-          gapH4,
-          StaggeredGrid.count(
-            axisDirection: AxisDirection.down,
-            crossAxisCount: 2,
-            mainAxisSpacing: Sizes.p4,
-            crossAxisSpacing: Sizes.p4,
-            children: [
-              for (var result in roundResult.resultsOrderByRank) ...[
-                StaggeredGridTile.count(
-                  crossAxisCellCount: 1,
-                  mainAxisCellCount: 0.4,
-                  child: GestureDetector(
-                    onTap: () async {
-                      await showDialog(
-                        context: context,
-                        builder: (context) => UserProfileDialog(
-                          user: result.user!,
-                        ),
-                      );
-                    },
-                    child: Container(
-                      padding: paddingV8H8,
-                      decoration: BoxDecoration(
-                        color: Theme.of(context)
-                            .colorScheme
-                            .surfaceContainerHighest,
-                        borderRadius:
-                            const BorderRadius.all(Radius.circular(15)),
-                      ),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceAround,
-                        children: [
-                          Expanded(
-                            flex: 2,
-                            child: Column(
-                              children: [
-                                if (result.rank == 1)
-                                  Expanded(
-                                    flex: 1,
-                                    child: CachedNetworkImage(
-                                        width: Sizes.p16,
-                                        height: Sizes.p16,
-                                        imageUrl: AppIconUrls.crown),
-                                  )
-                                else
-                                  const Expanded(flex: 1, child: SizedBox()),
-                                Text(
-                                  result.rank.toString(),
-                                  style: const TextStyle(
-                                    fontSize: Sizes.p16,
-                                  ),
-                                ),
-                                Expanded(
-                                  flex: 2,
-                                  child: Text(
-                                    result.totalPoints.toString(),
-                                    textAlign: TextAlign.center,
-                                    style: TextStyle(
-                                      fontSize: Sizes.p12,
-                                      color: result.totalPoints > 0
-                                          ? Colors.blueAccent
-                                          : result.totalPoints < 0
-                                              ? Colors.redAccent
-                                              : Theme.of(context)
-                                                  .colorScheme
-                                                  .inverseSurface,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                          Expanded(
-                            flex: 2,
-                            child: CircleAvatar(
-                              child: CachedNetworkImage(
-                                  imageUrl: result.user!.avatarUrl),
-                            ),
-                          ),
-                          Expanded(
-                            flex: 4,
-                            child: Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                AutoSizeText(
-                                  result.user!.name,
-                                  minFontSize: Sizes.p8,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                                gapH8,
-                                AutoSizeText(
-                                  result.score.toString(),
-                                  minFontSize: Sizes.p8,
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ],
-          ),
-        ],
-      ),
     );
   }
 }

--- a/jong_connect/pubspec.lock
+++ b/jong_connect/pubspec.lock
@@ -350,6 +350,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.3"
+  custom_refresh_indicator:
+    dependency: "direct main"
+    description:
+      name: custom_refresh_indicator
+      sha256: c34dd1dfb1f6b9ee2db9c5972586dba5e4445d79f8431f6ab098a6e963ccd39c
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
   dart_style:
     dependency: transitive
     description:

--- a/jong_connect/pubspec.yaml
+++ b/jong_connect/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
   floating_action_bubble: ^1.1.4
   badges: ^3.1.2
   collection: ^1.18.0
+  custom_refresh_indicator: ^4.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 変更内容
* ホーム画面、グループ詳細画面に表示していた最近の対局結果のUIデザイン調整
  * ルーム名、シーズン名、対局時間追加
  *  ユーザーアイコンも表示し視認性上げる
* ホーム画面でpullすることで更新可能に